### PR TITLE
test: separates util functions and adds tests to them

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,9 @@
+root = true
+
+[*]
+end_of_line = lf
+insert_final_newline = false
+indent_style = space
+indent_size = 2
+trim_trailing_whitespace = true
+insert_final_newline = true

--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 node_modules
+coverage

--- a/__tests__/fixtures/index.js
+++ b/__tests__/fixtures/index.js
@@ -1,0 +1,59 @@
+/** TODO: REMOVE THIS HORRIBLE HACK and ignore this file properly in jest config. */
+it('exposes fixtures', () => {})
+
+exports.removeStyleTagsParam = `
+<style lang="scss" scoped>
+.321312 {
+
+}
+</style>`;
+
+exports.removeStyleTagsExpectedResult = `.321312 {\n\n}`
+
+exports.removeScriptTagsParam = `
+<script>
+import NavMenu from './NavMenu'
+
+export default {
+    name: 'app',
+
+    components: {
+    NavMenu
+    }
+}
+</script>
+`
+
+exports.removeScriptTagsExpectedResult = `import NavMenu from './NavMenu'
+
+export default {
+    name: 'app',
+
+    components: {
+    NavMenu
+    }
+}`
+
+exports.entireVueFile = `
+<template>
+<div></div>
+</template>
+
+<script>
+import NavMenu from './NavMenu'
+
+export default {
+  name: 'app',
+
+  components: {
+    NavMenu
+  }
+}
+</script>
+
+<style lang="scss" scoped>
+.class {
+  border-style: dashed !important;
+}
+</style>
+`;

--- a/index.js
+++ b/index.js
@@ -1,31 +1,11 @@
 #!/usr/bin/env node
 const opts = require('minimist')(process.argv.slice(2))
 
-if (opts.help || opts.h) {
-  console.log(`
-    Usage:
-      You can run it without args and it will use the current
-      directory as base and look for a .prettierrc file to use
-      as prettier config and .vue files inside a ./src folder.
-
-      You can change this behavior with the following options:
-
-      (command)   (default)
-      --baseDir  'process.cwd()'
-        Change path used as base for config and root paths
-
-      --rootDir   './src'
-        Change dir where .vue files will be searched
-
-      --noisy     false
-        Wether to print the path of files being formatted
-
-      --help|-h
-        Show this help
-  `)
-  return
-}
-
 const PrettierVue = require('./src/lib')
+const app = require('./src/app');
 
-new PrettierVue(opts)
+const output = app(opts, () => new PrettierVue(opts))
+
+if (typeof output === 'string') {
+  console.log(output)
+}

--- a/package.json
+++ b/package.json
@@ -2,7 +2,8 @@
   "name": "prettier-vue",
   "version": "1.0.8",
   "scripts": {
-    "patch-release": "npm version patch && npm publish && git push --follow-tags"
+    "patch-release": "npm version patch && npm publish && git push --follow-tags",
+    "test": "jest"
   },
   "bin": {
     "prettier-vue": "./index.js"

--- a/src/app.js
+++ b/src/app.js
@@ -1,0 +1,9 @@
+const { help: helpMessage } = require('./messages')
+
+module.exports = (opts, runnable) => {
+  if (opts.help || opts.h) {
+    return helpMessage
+  }
+
+  runnable(opts)
+}

--- a/src/app.spec.js
+++ b/src/app.spec.js
@@ -1,0 +1,23 @@
+const app = require('./app')
+const { help: helpMessage } = require('./messages')
+
+describe('src/app.js', () => {
+  it('should return help string if help is provided', () => {
+    const output = app({ help: true })
+
+    expect(output).toBe(helpMessage)
+  })
+
+  it('should run runnable passing opts if help is not provided', () => {
+    const runnable = jest.fn()
+
+    const options = {
+      any: 321
+    }
+
+    const output = app(options, runnable)
+
+    expect(output).toBeUndefined()
+    expect(runnable).toHaveBeenCalledWith(options)
+  })
+})

--- a/src/lib.js
+++ b/src/lib.js
@@ -1,43 +1,11 @@
-const regexIndexOf = require('./util').regexIndexOf
-const writeToFile = require('./util').writeToFile
-const findit = require('findit')
 const fs = require('fs')
+const findit = require('findit')
 const prettier = require('prettier')
 
-const VUE_EXT = '.vue'
+const pureUtils = require('./utils')
 
-const STYLE_START = /<style.*>/gi
-const STYLE_END = /<\/style>/gi
-
-const SCRIPT_START = /<script.*>/gi
-const SCRIPT_END = /<\/script>/gi
-
-const isChanged = lang => lang.content !== lang.formatted
-const isVueSFC = filePath => filePath.indexOf(VUE_EXT) > -1
-
-const separateTags = substring => {
-  const splitted = substring.trim().split('\n')
-
-  if (!splitted.length || !splitted[0]) return
-
-  return splitted.slice(1, splitted.length - 1).join('\n')
-}
-
-const split = (str, startTag, endTag) => {
-  const sub = str.substring(
-    regexIndexOf(str, startTag),
-    regexIndexOf(str, endTag, true)
-  )
-
-  return { content: separateTags(sub) }
-}
-
-const splitChunks = str => {
-  const scss = split(str, STYLE_START, STYLE_END)
-  const js = split(str, SCRIPT_START, SCRIPT_END)
-
-  return { scss, js }
-}
+const { isVueSFC, writeToFile, splitChunks, isChanged } = pureUtils(fs)
+const { STYLE_START, STYLE_END, SCRIPT_START, SCRIPT_END } = pureUtils.constants
 
 class PrettierVue {
   constructor(opts) {

--- a/src/lib.spec.js
+++ b/src/lib.spec.js
@@ -1,0 +1,7 @@
+const PrettierVue = require('./lib')
+
+describe('src/lib.js', () => {
+  it('should be instanciable', () => {
+    new PrettierVue({})
+  })
+})

--- a/src/messages.js
+++ b/src/messages.js
@@ -1,0 +1,23 @@
+module.exports = {
+  help: `
+    Usage:
+        You can run it without args and it will use the current
+        directory as base and look for a .prettierrc file to use
+        as prettier config and .vue files inside a ./src folder.
+
+        You can change this behavior with the following options:
+
+        (command)   (default)
+        --baseDir  'process.cwd()'
+        Change path used as base for config and root paths
+
+        --rootDir   './src'
+        Change dir where .vue files will be searched
+
+        --noisy     false
+        Wether to print the path of files being formatted
+
+        --help|-h
+        Show this help
+    `
+}

--- a/src/utils/constants/index.js
+++ b/src/utils/constants/index.js
@@ -1,0 +1,7 @@
+exports.VUE_EXT = '.vue'
+
+exports.STYLE_START = /<style.*>/gi
+exports.STYLE_END = /<\/style>/gi
+
+exports.SCRIPT_START = /<script.*>/gi
+exports.SCRIPT_END = /<\/script>/gi

--- a/src/utils/constants/index.spec.js
+++ b/src/utils/constants/index.spec.js
@@ -1,0 +1,24 @@
+const constants = require('./')
+
+it('should expose VUE_EXT as .vue', () => {
+  expect(constants.VUE_EXT).toBeDefined()
+  expect(constants.VUE_EXT).toBe('.vue')
+})
+
+it('should expose STYLE_START regex', () => {
+  expect(constants.STYLE_START).toBeDefined()
+  expect(constants.STYLE_START).toEqual(/<style.*>/gi)
+})
+
+it('should expose STYLE_END regex', () => {
+  expect(constants.STYLE_END).toBeDefined()
+  expect(constants.STYLE_END).toEqual(/<\/style>/gi)
+})
+it('should expose SCRIPT_START regex', () => {
+  expect(constants.SCRIPT_START).toBeDefined()
+  expect(constants.SCRIPT_START).toEqual(/<script.*>/gi)
+})
+it('should expose SCRIPT_END regex', () => {
+  expect(constants.SCRIPT_END).toBeDefined()
+  expect(constants.SCRIPT_END).toEqual(/<\/script>/gi)
+})

--- a/src/utils/index.js
+++ b/src/utils/index.js
@@ -1,0 +1,22 @@
+const isVueSFC = require('./is-vue-sfc')
+const regexIndexOf = require('./regex-index-of')
+const writeToFile = require('./write-to-file')
+const separateTags = require('./separate-tags')
+const split = require('./split')
+const splitChunks = require('./split-chunks')
+const isChanged = require('./is-changed')
+const constants = require('./constants')
+
+const utils = fs => ({
+  isVueSFC: isVueSFC,
+  regexIndexOf: regexIndexOf,
+  split: split,
+  splitChunks: splitChunks,
+  separateTags: separateTags,
+  isChanged: isChanged,
+  writeToFile: writeToFile(fs)
+})
+
+utils.constants = constants
+
+module.exports = utils

--- a/src/utils/index.spec.js
+++ b/src/utils/index.spec.js
@@ -1,0 +1,24 @@
+const utils = require('./')
+const constants = require('./constants')
+
+it('should expose a function that accepts the filesystem as dependency', () => {
+  expect(typeof utils).toBe('function')
+})
+
+it('should return an object with utils methods', () => {
+  const fs = jest.fn()
+
+  const testUtils = utils(fs)
+
+  expect(testUtils.isVueSFC).toBeDefined()
+  expect(testUtils.writeToFile).toBeDefined()
+  expect(testUtils.regexIndexOf).toBeDefined()
+  expect(testUtils.separateTags).toBeDefined()
+  expect(testUtils.split).toBeDefined()
+  expect(testUtils.splitChunks).toBeDefined()
+  expect(testUtils.isChanged).toBeDefined()
+})
+
+it('should expose constants', () => {
+  expect(utils.constants).toBe(constants)
+})

--- a/src/utils/is-changed/index.js
+++ b/src/utils/is-changed/index.js
@@ -1,0 +1,1 @@
+module.exports = lang => lang.content !== lang.formatted

--- a/src/utils/is-changed/index.spec.js
+++ b/src/utils/is-changed/index.spec.js
@@ -1,0 +1,15 @@
+const isChanged = require('./')
+
+it('should be a function', () => {
+  expect(typeof isChanged).toBe('function')
+})
+it('should return if lang.content is different from lang.formatted', () => {
+  const param = {
+    content: 'foo',
+    formatted: 'bar'
+  }
+
+  const result = isChanged(param)
+
+  expect(result).toBeTruthy()
+})

--- a/src/utils/is-vue-sfc/index.js
+++ b/src/utils/is-vue-sfc/index.js
@@ -1,0 +1,3 @@
+const { VUE_EXT } = require('../constants')
+
+module.exports = path => path.indexOf(VUE_EXT) > -1

--- a/src/utils/is-vue-sfc/index.spec.js
+++ b/src/utils/is-vue-sfc/index.spec.js
@@ -1,0 +1,10 @@
+const isVueSFC = require('./')
+const { VUE_EXT } = require('../constants')
+
+it(`return true if has ${VUE_EXT} in path`, () => {
+  expect(isVueSFC(`./file${VUE_EXT}`)).toBeTruthy()
+})
+
+it(`return false if it doesn't has  ${VUE_EXT} in path`, () => {
+  expect(isVueSFC('./file.js')).toBeFalsy()
+})

--- a/src/utils/regex-index-of/index.js
+++ b/src/utils/regex-index-of/index.js
@@ -1,5 +1,3 @@
-const fs = require('fs')
-
 const regexIndexOf = (text, regex, isEnd) => {
   isEnd = isEnd || false
 
@@ -13,12 +11,4 @@ const regexIndexOf = (text, regex, isEnd) => {
   return isEnd ? endIdx : startIdx
 }
 
-const writeToFile = (path, content) => {
-  try {
-    fs.writeFileSync(path, content, 'utf8')
-  } catch (err) {
-    console.log(error)
-  }
-}
-
-module.exports = { regexIndexOf, writeToFile }
+module.exports = regexIndexOf

--- a/src/utils/regex-index-of/index.spec.js
+++ b/src/utils/regex-index-of/index.spec.js
@@ -1,0 +1,4 @@
+const regexIndexOf = require('./')
+
+/** TODO: Write tests for this */
+it('should do something')

--- a/src/utils/separate-tags/index.js
+++ b/src/utils/separate-tags/index.js
@@ -1,0 +1,7 @@
+module.exports = substring => {
+  const splitted = substring.trim().split('\n')
+
+  if (!splitted.length || !splitted[0]) return
+
+  return splitted.slice(1, splitted.length - 1).join('\n')
+}

--- a/src/utils/separate-tags/index.spec.js
+++ b/src/utils/separate-tags/index.spec.js
@@ -1,0 +1,23 @@
+const separateTags = require('./')
+const fixtures = require('../../../__tests__/fixtures')
+
+it('should remove style tags and return tag content', () => {
+  const param = fixtures.removeStyleTagsParam
+  const expectedResult = fixtures.removeStyleTagsExpectedResult
+
+  const result = separateTags(param)
+  expect(result).toBe(expectedResult)
+})
+
+it('should remove script tags and return tag content', () => {
+  const param = fixtures.removeScriptTagsParam
+  const expectedResult = fixtures.removeScriptTagsExpectedResult
+
+  const result = separateTags(param)
+  expect(result).toBe(expectedResult)
+})
+
+it('should return undefined when string is empty', () => {
+  const result = separateTags('')
+  expect(result).toBeUndefined()
+})

--- a/src/utils/split-chunks/index.js
+++ b/src/utils/split-chunks/index.js
@@ -1,0 +1,15 @@
+const split = require('../split')
+
+const {
+  STYLE_START,
+  STYLE_END,
+  SCRIPT_START,
+  SCRIPT_END
+} = require('../constants')
+
+module.exports = str => {
+  const scss = split(str, STYLE_START, STYLE_END)
+  const js = split(str, SCRIPT_START, SCRIPT_END)
+
+  return { scss, js }
+}

--- a/src/utils/split-chunks/index.spec.js
+++ b/src/utils/split-chunks/index.spec.js
@@ -1,0 +1,20 @@
+const splitChunks = require('./')
+const fixtures = require('../../../__tests__/fixtures')
+it('should be a function', () => {
+  expect(typeof splitChunks).toBe('function')
+})
+
+it('should extract both scss and js chunks and return as an object', () => {
+  const result = splitChunks(fixtures.entireVueFile)
+
+  expect(result.js).toBeDefined()
+  expect(result.scss).toBeDefined()
+
+  expect(result.js).toEqual({
+    content: `import NavMenu from \'./NavMenu\'\n\nexport default {\n  name: \'app\',\n\n  components: {\n    NavMenu\n  }\n}`
+  })
+
+  expect(result.scss).toEqual({
+    content: `.class {\n  border-style: dashed !important;\n}`
+  })
+})

--- a/src/utils/split/index.js
+++ b/src/utils/split/index.js
@@ -1,0 +1,11 @@
+const regexIndexOf = require('../regex-index-of')
+const separateTags = require('../separate-tags')
+
+module.exports = (str, startTag, endTag) => {
+  const sub = str.substring(
+    regexIndexOf(str, startTag),
+    regexIndexOf(str, endTag, true)
+  )
+
+  return { content: separateTags(sub) }
+}

--- a/src/utils/split/index.spec.js
+++ b/src/utils/split/index.spec.js
@@ -1,0 +1,29 @@
+const {
+  STYLE_START,
+  STYLE_END,
+  SCRIPT_START,
+  SCRIPT_END
+} = require('../constants')
+
+const split = require('./')
+const fixtures = require('../../../__tests__/fixtures')
+
+it('should be a function', () => {
+  expect(typeof split).toBe('function')
+})
+
+it('should be able to extract scss chunks', () => {
+  const result = split(fixtures.removeStyleTagsParam, STYLE_START, STYLE_END)
+
+  expect(result).toEqual({
+    content: fixtures.removeStyleTagsExpectedResult
+  })
+})
+
+it('should be able to extract js chunks', () => {
+  const result = split(fixtures.removeScriptTagsParam, SCRIPT_START, SCRIPT_END)
+
+  expect(result).toEqual({
+    content: fixtures.removeScriptTagsExpectedResult
+  })
+})

--- a/src/utils/write-to-file/index.js
+++ b/src/utils/write-to-file/index.js
@@ -1,0 +1,13 @@
+const injectableWriteToFile = fs => {
+  const writeToFile = (path, content) => {
+    try {
+      fs.writeFileSync(path, content, 'utf8')
+    } catch (err) {
+      console.log(err)
+    }
+  }
+
+  return writeToFile
+}
+
+module.exports = injectableWriteToFile

--- a/src/utils/write-to-file/index.spec.js
+++ b/src/utils/write-to-file/index.spec.js
@@ -1,0 +1,43 @@
+const writeToFile = require('./')
+
+it('should call to fs.writeFileSync', () => {
+  const testFs = {
+    writeFileSync: jest.fn()
+  }
+
+  const testableWriteToFile = writeToFile(testFs)
+  const testPath = './any/path/foo.bar'
+  const testContent = 'content'
+
+  testableWriteToFile(testPath, testContent)
+
+  expect(testFs.writeFileSync).toHaveBeenCalledWith(
+    testPath,
+    testContent,
+    'utf8'
+  )
+})
+
+it('should handle error when thrown', () => {
+  /** TODO: Find a better way to handle errors */
+  console.log = jest.fn()
+
+  const error = new Error('file missing')
+
+  const problematicFs = {
+    writeFileSync: () => {
+      throw error
+    }
+  }
+
+  const testableWriteToFile = writeToFile(problematicFs)
+
+  const testPath = './any/path/foo.bar'
+  const testContent = 'content'
+
+  testableWriteToFile(testPath, testContent)
+
+  expect(console.log).toBeCalledWith(error)
+
+  console.log.mockRestore()
+})


### PR DESCRIPTION

This PR modifies some part of the code structure, as it:

 - Create a new `utils` module with every kind of utility needed by the `PrettierVue` class. 
 - Adds some higher order functions for injecting dependencies and ease testing parts that depend on external services.
 - Adds some fixtures for testing functions like `split` and `splitChunks`.
 - Adds some `TODO`s as well for testing some components.

This PR still does not implement a full test in the `src/lib` file, the `PrettierVue` instance in case.
I thought that there already has too many changes for a PR, so I'm submitting this one first.

Please do some tests in your local machine to assure everything is ok.

This PR increases the code coverage from 0% to almost 70%.